### PR TITLE
Do not attempt to decode PUTDATA and POSTDATA if utf8 and/or NO_NULL is set

### DIFF
--- a/lib/CGI/Simple.pm
+++ b/lib/CGI/Simple.pm
@@ -432,9 +432,10 @@ sub _add_param {
     next
      if $value eq ''
        and $self->{'.globals'}->{'NO_UNDEF_PARAMS'};
-    $value =~ tr/\000//d if $self->{'.globals'}->{'NO_NULL'} and $param ne 'PUTDATA';
+    $value =~ tr/\000//d 
+     if $self->{'.globals'}->{'NO_NULL'} and $param ne 'PUTDATA' and $param ne 'POSTDATA';
     $value = Encode::decode( utf8 => $value )
-     if $self->{'.globals'}->{PARAM_UTF8} and $param ne 'PUTDATA';
+     if $self->{'.globals'}->{PARAM_UTF8} and $param ne 'PUTDATA' and $param ne 'POSTDATA';
     push @{ $self->{$param} }, $value;
     unless ( $self->{'.fieldnames'}->{$param} ) {
       push @{ $self->{'.parameters'} }, $param;

--- a/lib/CGI/Simple.pm
+++ b/lib/CGI/Simple.pm
@@ -432,9 +432,9 @@ sub _add_param {
     next
      if $value eq ''
        and $self->{'.globals'}->{'NO_UNDEF_PARAMS'};
-    $value =~ tr/\000//d if $self->{'.globals'}->{'NO_NULL'};
+    $value =~ tr/\000//d if $self->{'.globals'}->{'NO_NULL'} and $param ne 'PUTDATA';
     $value = Encode::decode( utf8 => $value )
-     if $self->{'.globals'}->{PARAM_UTF8};
+     if $self->{'.globals'}->{PARAM_UTF8} and $param ne 'PUTDATA';
     push @{ $self->{$param} }, $value;
     unless ( $self->{'.fieldnames'}->{$param} ) {
       push @{ $self->{'.parameters'} }, $param;
@@ -505,7 +505,7 @@ sub _parse_multipart {
     while ( $data =~ m/^$boundary$CRLF/ ) {
       ## TAB and high ascii chars are definitivelly allowed in headers.
       ## Not accepting them in the following regex prevents the upload of
-      ## files with filenames like "España.txt".
+      ## files with filenames like "EspaÃ±a.txt".
       # next READ unless $data =~ m/^([\040-\176$CRLF]+?$CRLF$CRLF)/o;
       next READ
        unless $data =~ m/^([\x20-\x7E\x80-\xFF\x09$CRLF]+?$CRLF$CRLF)/o;


### PR DESCRIPTION
We try to use `CGI::Simple` in our `CGI::Application` based REST app. We have in general enabled utf8 and are running into problems when uploading data via `PUT` request as `CGI::Simple` per default tries to decode all params via ` Encode::decode` in sub `_add_param`. 

Another point is that if `$CGI::Simple::NO_NULL` is set to 1 (which is the default) `CGI::Simple` eliminates zero bytes from PUTDATA and POSTDATA, which should not happen in case of binary data.

When uploading binary files  (e.g. zip archives via curl) this results in corruption of the uploaded data, not containing a valid zip archive anymore.

This PR disables alteration and decoding of the `PUTDATA` and `POSTDATA`param value.

This is the same bug as reported by mgruzdev at rt.cpan.org:
https://rt.cpan.org/Public/Bug/Display.html?id=95828

We would greatly appreciate if this PR is merged and a new version of `CGI::Simple` is published at cpan.