### PR TITLE
Set max-age attribute correctly from constructor

### DIFF
--- a/lib/CGI/Simple/Cookie.pm
+++ b/lib/CGI/Simple/Cookie.pm
@@ -96,7 +96,7 @@ sub new {
   $self->domain( $domain )     if defined $domain;
   $self->secure( $secure )     if defined $secure;
   $self->expires( $expires )   if defined $expires;
-  $self->max_age( $expires )   if defined $max_age;
+  $self->max_age( $max_age )   if defined $max_age;
   $self->httponly( $httponly ) if defined $httponly;
   return $self;
 }
@@ -285,6 +285,7 @@ L<http://www.owasp.org/index.php/HTTPOnly>
     $c = CGI::Simple::Cookie->new( -name    =>  'foo',
                                   -value   =>  'bar',
                                   -expires =>  '+3M',
+                                  -max-age =>  '+3M',
                                   -domain  =>  '.capricorn.com',
                                   -path    =>  '/cgi-bin/database',
                                   -secure  =>  1

--- a/t/020.cookie.t
+++ b/t/020.cookie.t
@@ -11,7 +11,7 @@ BEGIN {
 
 use strict;
 use warnings;
-use Test::More tests => 99;
+use Test::More tests => 106;
 use Test::NoWarnings;
 
 use CGI::Simple::Util qw(escape unescape);
@@ -194,6 +194,7 @@ my @test_cookie = (
   is( $c->name,  'baz', 'name is correct' );
   is( $c->value, 'qux', 'value is correct' );
   ok( !defined $c->expires, 'expires is not set' );
+  ok( !defined $c->max_age, 'max_age is not set' );
   ok( !defined $c->domain,  'domain attributeis not set' );
   is( $c->path, '/', 'path atribute is set to default' );
   ok( !defined $c->secure,   'secure attribute is not set' );
@@ -224,13 +225,14 @@ my @test_cookie = (
 
 {
   my $c = CGI::Simple::Cookie->new(
-    -name     => 'Jam',
-    -value    => 'Hamster',
-    -expires  => '+3M',
-    -domain   => '.pie-shop.com',
-    -path     => '/',
-    -secure   => 1,
-    -httponly => 1
+    -name      => 'Jam',
+    -value     => 'Hamster',
+    -expires   => '+3M',
+    '-max-age' => '+3M',
+    -domain    => '.pie-shop.com',
+    -path      => '/',
+    -secure    => 1,
+    -httponly  => 1
   );
 
   my $name = $c->name;
@@ -243,6 +245,10 @@ my @test_cookie = (
   my $expires = $c->expires;
   like( $c->as_string, "/$expires/",
     "Stringified cookie contains expires" );
+
+  my $max_age = $c->max_age;
+  like( $c->as_string, "/$max_age/",
+    "Stringified cookie contains max_age" );
 
   my $domain = $c->domain;
   like( $c->as_string, "/$domain/",
@@ -271,6 +277,9 @@ my @test_cookie = (
 
   ok( $c->as_string !~ /expires/,
     "Stringified cookie has no expires field" );
+
+  ok( $c->as_string !~ /max-age/,
+    "Stringified cookie has no max_age field" );
 
   ok( $c->as_string !~ /domain/,
     "Stringified cookie has no domain field" );
@@ -427,6 +436,24 @@ MAX_AGE: {
 
     $cookie->max_age( '113' );
     is $cookie->max_age => 13, 'max_age(num) as delta';
+  }
+
+  {
+    my $cookie
+     = CGI::Simple::Cookie->new( -name=>'a', value=>'b', '-max-age' => '+3d');
+    is( $cookie->max_age,3*24*60*60,'-max-age in constructor' );
+    ok( !$cookie->expires,' ... lack of expires' );
+  }
+
+  {
+    my $cookie = CGI::Simple::Cookie->new(
+      -name    => 'a',
+      value    => 'b',
+      -expires => 'now',
+      '-max-age' => '+3d'
+    );
+    is( $cookie->max_age,3*24*60*60,'-max-age in constructor' );
+    ok( $cookie->expires,'-expires in constructor' );
   }
 }
 


### PR DESCRIPTION
This patch (largely the same as leejo/CGI.pm@7d46fae0f0b) fixes an issue with the handling of the `-max-age` parameter to the constructor, and resolves [RT #124006](https://rt.cpan.org/Public/Bug/Display.html?id=124006).

This pull request courtesy of the PRC~
