### PR TITLE
Change the name of 302 statuses from Moved to Found

### DIFF
--- a/lib/CGI/Simple.pm
+++ b/lib/CGI/Simple.pm
@@ -1115,7 +1115,7 @@ sub redirect {
   my @o;
   for ( @other ) { tr/\"//d; push @o, split "=", $_, 2; }
   unshift @o,
-   '-Status'   => '302 Moved',
+   '-Status'   => '302 Found',
    '-Location' => $url,
    '-nph'      => $nph;
   unshift @o, '-Target' => $target if $target;

--- a/t/030.function.t
+++ b/t/030.function.t
@@ -93,7 +93,7 @@ is(
 
 is(
   redirect( 'http://somewhere.else' ),
-  "Status: 302 Moved${CRLF}Location: http://somewhere.else${CRLF}${CRLF}",
+  "Status: 302 Found${CRLF}Location: http://somewhere.else${CRLF}${CRLF}",
   "CGI::redirect() 1"
 );
 
@@ -104,7 +104,7 @@ my $h = redirect(
 
 is(
   $h,
-  "Status: 302 Moved${CRLF}Location: http://somewhere.else${CRLF}"
+  "Status: 302 Found${CRLF}Location: http://somewhere.else${CRLF}"
    . "Content-Type: text/html; charset=ISO-8859-1${CRLF}${CRLF}",
   "CGI::redirect() 2"
 );
@@ -114,7 +114,7 @@ is(
     -Location => 'http://somewhere.else/bin/foo&bar',
     -Type     => 'text/html'
   ),
-  "Status: 302 Moved${CRLF}Location: http://somewhere.else/bin/foo&bar${CRLF}"
+  "Status: 302 Found${CRLF}Location: http://somewhere.else/bin/foo&bar${CRLF}"
    . "Content-Type: text/html; charset=ISO-8859-1${CRLF}${CRLF}",
   "CGI::redirect() 2"
 );

--- a/t/050.simple.t
+++ b/t/050.simple.t
@@ -914,7 +914,7 @@ ok( $sv =~ /Date:$1GMT/ . 'cache(1), 4' );
 # redirect() - scalar and array context, void argument
 $sv     = $q->redirect( 'http://a.galaxy.far.away.gov' );
 $header = <<'HEADER';
-Status: 302 Moved
+Status: 302 Found
 Expires: Tue, 13 Nov 2001 06:45:15 GMT
 Date: Tue, 13 Nov 2001 06:45:15 GMT
 Pragma: no-cache
@@ -929,9 +929,9 @@ is( $sv, $header, 'redirect(), 1' );
 # redirect() - scalar and array context, void argument
 $sv = $q->redirect( -uri => 'http://a.galaxy.far.away.gov', -nph => 1 );
 $header = <<'HEADER';
-HTTP/1.0 302 Moved
+HTTP/1.0 302 Found
 Server: Apache - accept no substitutes
-Status: 302 Moved
+Status: 302 Found
 Expires: Tue, 13 Nov 2001 06:49:24 GMT
 Date: Tue, 13 Nov 2001 06:49:24 GMT
 Pragma: no-cache

--- a/t/070.standard.t
+++ b/t/070.standard.t
@@ -920,7 +920,7 @@ is(
 
 $sv     = redirect( 'http://a.galaxy.far.away.gov' );
 $header = <<'HEADER';
-Status: 302 Moved
+Status: 302 Found
 Expires: Tue, 13 Nov 2001 06:45:15 GMT
 Date: Tue, 13 Nov 2001 06:45:15 GMT
 Pragma: no-cache
@@ -936,9 +936,9 @@ is( $sv, $header, 'redirect(), 1' );
 
 $sv = redirect( -uri => 'http://a.galaxy.far.away.gov', -nph => 1 );
 $header = <<'HEADER';
-HTTP/1.0 302 Moved
+HTTP/1.0 302 Found
 Server: Apache - accept no substitutes
-Status: 302 Moved
+Status: 302 Found
 Expires: Tue, 13 Nov 2001 06:49:24 GMT
 Date: Tue, 13 Nov 2001 06:49:24 GMT
 Pragma: no-cache


### PR DESCRIPTION
This patch changes the string sent for 302 responses from "Moved" to "Found".

In favour of this change:

* This is the current behaviour in CGI.
* This is the name given in [RFC 2616, section 10.3.3][1].
* This is the string listed in the documentation in this distribution (under ['Creating HTTP headers'][2]).

[1]: https://tools.ietf.org/html/rfc2616#section-10.3.3
[2]: https://github.com/manwar/CGI--Simple/blob/a36d5b77128158d6612f5b1dbd2d87d0363663cc/lib/CGI/Simple.pm#L2489

This resolves [RT #75356](https://rt.cpan.org/Public/Bug/Display.html?id=75356).