### PR TITLE
close left-over handles that can cause test failures on windows

### DIFF
--- a/t/050.simple.t
+++ b/t/050.simple.t
@@ -640,6 +640,7 @@ my $ok = $q->upload( '/some/path/to/myfile', "$tmpfile.bak" );
 is( $ok, 1, 'upload(\'invalid\'), 3' );
 open $handle, "$tmpfile.bak" or carp "Can't read $tmpfile.bak $!\n";
 $upload = join '', <$handle>;
+close $handle;
 is( $upload, $data, 'upload(\'invalid\'), 4' );
 $sv = $q->upload( '/some/path/to/myfile', "$tmpfile.bak" );
 is( $sv, undef, 'upload(\'invalid\'), 5' );

--- a/t/070.standard.t
+++ b/t/070.standard.t
@@ -619,6 +619,7 @@ my $ok = upload( '/some/path/to/myfile', "$tmpfile.bak" );
 is( $ok, 1, 'upload( \'/some/path/to/myfile\', \, 1' );
 open $handle, "$tmpfile.bak" or carp "Can't read $tmpfile.bak $!\n";
 $upload = join '', <$handle>;
+close $handle;
 is( $upload, $data, 'upload( \'/some/path/to/myfile\', \, 2' );
 $sv = upload( '/some/path/to/myfile', "$tmpfile.bak" );
 is( $sv, undef, 'upload( \'/some/path/to/myfile\', \, 3' );


### PR DESCRIPTION
This allows CGI::Simple (and thus all of its dependencies like Catalyst) to install on Windows again, so i think it's fairly important.

The test failure looked like this:

    #       cannot unlink file for C:\Users\Mithaldu\AppData\Local\Temp\grNWbxnpm0\cgi-tmpfile.tmp.bak: Permission denied at C:/Strawberry/perl/lib/File/Temp.pm line 784.