### PR TITLE
fix for rt #124772 (test failure on Windows)

### DIFF
--- a/t/050.simple.t
+++ b/t/050.simple.t
@@ -643,6 +643,7 @@ $upload = join '', <$handle>;
 is( $upload, $data, 'upload(\'invalid\'), 4' );
 $sv = $q->upload( '/some/path/to/myfile', "$tmpfile.bak" );
 is( $sv, undef, 'upload(\'invalid\'), 5' );
+close($handle);
 unlink $tmpfile, "$tmpfile.bak";
 
 $ENV{'CONTENT_TYPE'} = 'application/x-www-form-urlencoded';

--- a/t/070.standard.t
+++ b/t/070.standard.t
@@ -622,6 +622,7 @@ $upload = join '', <$handle>;
 is( $upload, $data, 'upload( \'/some/path/to/myfile\', \, 2' );
 $sv = upload( '/some/path/to/myfile', "$tmpfile.bak" );
 is( $sv, undef, 'upload( \'/some/path/to/myfile\', \, 3' );
+close($handle);
 unlink $tmpfile, "$tmpfile.bak";
 
 $ENV{'CONTENT_TYPE'} = 'application/x-www-form-urlencoded';


### PR DESCRIPTION
Tests failed because test scripts tried to unlink a file while it was still open. A file cannot be unlinked on Windows while it is opened.

Fixes rt #124772