### PR TITLE
allow None for SameSite option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 branches:
   except:
     - gh-pages

--- a/lib/CGI/Simple/Cookie.pm
+++ b/lib/CGI/Simple/Cookie.pm
@@ -181,7 +181,7 @@ sub httponly {
   return $self->{'httponly'};
 }
 
-my %_legal_samesite = ( Strict => 1, Lax => 1 );
+my %_legal_samesite = ( Strict => 1, Lax => 1, None => 1 );
 sub samesite {
     my $self = shift;
     my $samesite = ucfirst lc +shift if @_; # Normalize casing.
@@ -290,7 +290,7 @@ L<http://www.owasp.org/index.php/HTTPOnly>
 
 =item B<6. samesite flag>
 
-Allowed settings are C<Strict> and C<Lax>.
+Allowed settings are C<Strict>, C<Lax> and C<None>.
 
 As of April 2018, support is limited mostly to recent releases of
 Chrome and Opera.
@@ -344,7 +344,7 @@ cookie only when a cryptographic protocol is in use.
 B<-httponly> if set to a true value, the cookie will not be accessible
 via JavaScript.
 
-B<-samesite> may be C<Lax> or C<Strict> and is an evolving part of the
+B<-samesite> may be C<Lax>, C<Strict> or C<None> and is an evolving part of the
 standards for cookies. Please refer to current documentation regarding it.
 
 =head2 Sending the Cookie to the Browser

--- a/t/020.cookie.t
+++ b/t/020.cookie.t
@@ -11,7 +11,7 @@ BEGIN {
 
 use strict;
 use warnings;
-use Test::More tests => 113;
+use Test::More tests => 115;
 use Test::NoWarnings;
 
 use CGI::Simple::Util qw(escape unescape);
@@ -423,6 +423,9 @@ my @test_cookie = (
   is( $c->samesite,           'Strict', 'SameSite is correct' );
   is( $c->samesite( 'Lax' ), 'Lax',    'SameSite is set correctly' );
   is( $c->samesite,          'Lax',    'SameSite now returns updated value' );
+
+  is( $c->samesite( 'None' ), 'None',    'SameSite is set correctly' );
+  is( $c->samesite,          'None',    'SameSite now returns updated value' );
 }
 
 #----------------------------------------------------------------------------


### PR DESCRIPTION
Chrome 80 demands "SateSite=None" for third party cookie.
https://blog.chromium.org/2019/10/developers-get-ready-for-new.html

This changes allows "None" for SameSite option.

