### PR TITLE
drop IO::Scalar prereq

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -15,7 +15,6 @@ my $builder = MyBuilder->new(
     'Test::More'       => 0,
     'Test::NoWarnings' => 0,
     'Test::Exception'  => 0,
-    'IO::Scalar'       => 0,
     'File::Temp'       => 0,
   },
   add_to_cleanup => ['CGI-Simple-*'],

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,7 +10,6 @@ my %conf = (
         'Test::More'       => 0,
         'Test::NoWarnings' => 0,
         'Test::Exception'  => 0,
-        'IO::Scalar'       => 0,
         'File::Temp'       => 0,
     },
     dist  => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },

--- a/t/041.multipart.t
+++ b/t/041.multipart.t
@@ -3,8 +3,6 @@ use warnings;
 use Test::More tests => 6;
 use Test::NoWarnings;
 use Config;
-use Data::Dumper;
-use IO::Scalar;
 
 use CGI::Simple ( -default );
 
@@ -40,7 +38,16 @@ Reply\r
 EOF
 $ENV{CONTENT_LENGTH} = length $body;
 
-my $h = IO::Scalar->new( \$body );
+my $h;
+if ("$]" < 5.008) {
+  require File::Temp;
+  $h = File::Temp->new(TEMPLATE => 'CGI-Simple-multipart-XXXXXX', TMPDIR => 1);
+  $h->print($body);
+  $h->seek(0, 0);
+}
+else {
+  open $h, '<', \$body;
+}
 my $q = CGI::Simple->new( $h );
 ok( $q, "CGI::Simple::new()" );
 is_deeply(

--- a/t/upload_info.t
+++ b/t/upload_info.t
@@ -1,7 +1,6 @@
 use Test::More tests => 3;
 use strict;
 use warnings;
-use IO::Scalar;
 
 use CGI::Simple;
 # Set up a CGI environment
@@ -44,7 +43,16 @@ fake\r
 EOF
 $ENV{CONTENT_LENGTH} = length $body;
 
-my $h = IO::Scalar->new( \$body );
+my $h;
+if ("$]" < 5.008) {
+  require File::Temp;
+  $h = File::Temp->new(TEMPLATE => 'CGI-Simple-upload_info-XXXXXX', TMPDIR => 1);
+  $h->print($body);
+  $h->seek(0, 0);
+}
+else {
+  open $h, '<', \$body;
+}
 my $q = CGI::Simple->new( $h );
 ok( $q->upload_info( $q->param( 'file0' ), 'mime' ) eq 'image/png',
   'Guess mime for  image/png' );


### PR DESCRIPTION
IO::Scalar is only needed for perl 5.6.  We can instead use temp files on perl versions that old, to avoid the useless prereq on modern perls.