### PR TITLE
RT-151161 Add CGI::Cookie partitioned support into CGI::Simple::Cookies

### DIFF
--- a/lib/CGI/Simple/Cookie.pm
+++ b/lib/CGI/Simple/Cookie.pm
@@ -75,14 +75,16 @@ sub new {
   $class = ref( $class ) || $class;
   my (
     $name,   $value,   $path,    $domain,
-    $secure, $expires, $max_age, $httponly, $samesite
+    $secure, $expires, $max_age, $httponly, $samesite,
+    $priority, $partitioned 
    )
    = rearrange(
     [
       'NAME', [ 'VALUE', 'VALUES' ],
       'PATH',    'DOMAIN',
       'SECURE',  'EXPIRES',
-      'MAX-AGE', 'HTTPONLY', 'SAMESITE'
+      'MAX-AGE', 'HTTPONLY', 'SAMESITE',
+      'PRIORITY', 'PARTITIONED',
     ],
     @params
    );
@@ -92,13 +94,15 @@ sub new {
   $self->name( $name );
   $self->value( $value );
   $path ||= "/";
-  $self->path( $path )         if defined $path;
-  $self->domain( $domain )     if defined $domain;
-  $self->secure( $secure )     if defined $secure;
-  $self->expires( $expires )   if defined $expires;
-  $self->max_age( $max_age )   if defined $max_age;
-  $self->httponly( $httponly ) if defined $httponly;
-  $self->samesite( $samesite ) if defined $samesite;
+  $self->path( $path )               if defined $path;
+  $self->domain( $domain )           if defined $domain;
+  $self->secure( $secure )           if defined $secure;
+  $self->expires( $expires )         if defined $expires;
+  $self->max_age( $max_age )         if defined $max_age;
+  $self->httponly( $httponly )       if defined $httponly;
+  $self->samesite( $samesite )       if defined $samesite;
+  $self->priority( $priority )       if defined $priority;
+  $self->partitioned( $partitioned ) if defined $partitioned;  
   return $self;
 }
 
@@ -115,6 +119,8 @@ sub as_string {
   push @cookie, "secure"                      if $self->secure;
   push @cookie, "HttpOnly"                    if $self->httponly;
   push @cookie, "SameSite=" . $self->samesite if $self->samesite;
+  push @cookie,"Priority=".$self->priority if $self->priority;
+  push @cookie,"Partitioned"               if $self->partitioned;
   return join "; ", @cookie;
 }
 
@@ -181,12 +187,28 @@ sub httponly {
   return $self->{'httponly'};
 }
 
+sub partitioned { # Partitioned
+    my ( $self, $partitioned ) = @_;
+    $self->{'partitioned'} = $partitioned if defined $partitioned;
+    return $self->{'partitioned'};
+}
+
 my %_legal_samesite = ( Strict => 1, Lax => 1, None => 1 );
 sub samesite {
     my $self = shift;
     my $samesite = ucfirst lc +shift if @_; # Normalize casing.
     $self->{'samesite'} = $samesite if $samesite and $_legal_samesite{$samesite};
     return $self->{'samesite'};
+}
+
+my %_legal_priority = ( Low => 1, Medium => 1, High => 1 );
+sub priority {
+    my $self = shift;
+    my $priority = ucfirst lc +shift if @_;
+    if ($priority && $_legal_priority{$priority}) {
+        $self->{'priority'} = $priority;
+    }
+    return $self->{'priority'};
 }
 
 1;
@@ -229,7 +251,8 @@ For full information on cookies see:
 
     http://tools.ietf.org/html/rfc2109
     http://tools.ietf.org/html/rfc2965
-
+    https://dcthetall.github.io/CHIPS-spec/draft-cutler-httpbis-partitioned-cookies.html
+    
 =head1 USING CGI::Simple::Cookie
 
 CGI::Simple::Cookie is object oriented.  Each cookie object has a name
@@ -296,6 +319,22 @@ As of April 2018, support is limited mostly to recent releases of
 Chrome and Opera.
 
 L<https://tools.ietf.org/html/draft-west-first-party-cookies-07>
+
+=item B<7. priority flag>
+
+This attribute allows servers to specify a retention priority for HTTP cookies 
+that will be respected by user agents during cookie eviction.
+
+Allowed settings are C<Low>, C<Medium> and C<High>.
+
+=item B<8. partitioned flag>
+
+If the "partitioned" attribute is set, the cookie is restricted to the 
+contexts in which a cookie is available to only those whose top-level 
+document is same-site with the top-level document that initiated the 
+request that created the cookie.
+
+L<https://dcthetall.github.io/CHIPS-spec/draft-cutler-httpbis-partitioned-cookies.html>
 
 =back
 
@@ -464,6 +503,14 @@ Get or set the cookie's HttpOnly flag.
 =item B<samesite()>
 
 Get or set the cookie's samesite value.
+
+=item B<priority()>
+
+Get or set the cookie's priority value.
+
+=item B<partitioned()>
+
+Get or set the cookies partitioned flag.
 
 =back
 

--- a/t/020.cookie.t
+++ b/t/020.cookie.t
@@ -162,15 +162,15 @@ my @test_cookie = (
 
   # Try new with full information provided
   my $c = CGI::Simple::Cookie->new(
-    -name     => 'foo',
-    -value    => 'bar',
-    -expires  => '+3M',
-    -domain   => '.capricorn.com',
-    -path     => '/cgi-bin/database',
-    -secure   => 1,
-    -httponly => 1,
-    -samesite => 'Lax',
-    -priority => 'High',
+    -name       => 'foo',
+    -value      => 'bar',
+    -expires    => '+3M',
+    -domain     => '.capricorn.com',
+    -path       => '/cgi-bin/database',
+    -secure     => 1,
+    -httponly   => 1,
+    -samesite   => 'Lax',
+    -priority   => 'High',
     -partitioned => 1
   );
   is( ref( $c ), 'CGI::Simple::Cookie',
@@ -233,17 +233,17 @@ my @test_cookie = (
 
 {
   my $c = CGI::Simple::Cookie->new(
-    -name      => 'Jam',
-    -value     => 'Hamster',
-    -expires   => '+3M',
-    '-max-age' => '+3M',
-    -domain    => '.pie-shop.com',
-    -path      => '/',
-    -secure    => 1,
-    -httponly  => 1,
-    -samesite  => 'strict'
-    -priority=> 'high',
-    -partitioned=> 1,
+    -name        => 'Jam',
+    -value       => 'Hamster',
+    -expires     => '+3M',
+    '-max-age'   => '+3M',
+    -domain      => '.pie-shop.com',
+    -path        => '/',
+    -secure      => 1,
+    -httponly    => 1,
+    -samesite    => 'strict',
+    -priority    => 'high',
+    -partitioned => 1,
   );
 
   my $name = $c->name;

--- a/t/020.cookie.t
+++ b/t/020.cookie.t
@@ -11,7 +11,7 @@ BEGIN {
 
 use strict;
 use warnings;
-use Test::More tests => 115;
+use Test::More tests => 122;
 use Test::NoWarnings;
 
 use CGI::Simple::Util qw(escape unescape);
@@ -169,7 +169,9 @@ my @test_cookie = (
     -path     => '/cgi-bin/database',
     -secure   => 1,
     -httponly => 1,
-    -samesite => 'Lax'
+    -samesite => 'Lax',
+    -priority => 'High',
+    -partitioned => 1
   );
   is( ref( $c ), 'CGI::Simple::Cookie',
     'new returns objects of correct type' );
@@ -185,6 +187,8 @@ my @test_cookie = (
   ok( $c->secure,   'secure attribute is set' );
   ok( $c->httponly, 'httponly attribute is set' );
   is( $c->samesite, 'Lax', 'samesite attribute is correct' );
+  is( $c->priority, 'High', 'priority attribute is correct' );
+  is( $c->partitioned, 1, 'partitioned attribute is correct' );
 
 # now try it with the only two manditory values (should also set the default path)
   $c = CGI::Simple::Cookie->new(
@@ -202,6 +206,7 @@ my @test_cookie = (
   ok( !defined $c->secure,   'secure attribute is not set' );
   ok( !defined $c->httponly, 'httponly attribute is not set' );
   ok( !defined $c->samesite, 'samesite attribute is not set' );
+  ok( !$c->partitioned, 'partitioned attribute is not set' );
 
   # I'm really not happy about the restults of this section.  You pass
   # the new method invalid arguments and it just merilly creates a
@@ -237,6 +242,8 @@ my @test_cookie = (
     -secure    => 1,
     -httponly  => 1,
     -samesite  => 'strict'
+    -priority=> 'high',
+    -partitioned=> 1,
   );
 
   my $name = $c->name;
@@ -270,6 +277,12 @@ my @test_cookie = (
   like( $c->as_string, '/SameSite=Strict/',
     "Stringified cookie contains normalized SameSite" );
 
+  like( $c->as_string, '/Priority=High/',
+    "Stringified cookie contains normalized Priority" );
+
+  like( $c->as_string, '/Partitioned/',
+    "Stringified cookie contains Partitioned" );
+
   $c = CGI::Simple::Cookie->new(
     -name  => 'Hamster-Jam',
     -value => 'Tulip',
@@ -302,6 +315,12 @@ my @test_cookie = (
 
   ok( $c->as_string !~ /SameSite/,
     "Stringified cookie does not contain SameSite" );
+
+  ok( $c->as_string !~ /Priority/,
+    "Stringified cookie does not contain Priority" );
+
+  ok( $c->as_string !~ /Partitioned/,
+    "Stringified cookie does not contain Partitioned" );
 }
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
Duplicates changes made to https://github.com/leejo/CGI.pm/pull/262 to bring Partitioned attribute functionality into CGI::Simple::Cookie.

Also added the same 'priority' attribute functionality to keep CGI::Simple::Cookie consistent with CGI::Cookie.

My apologies on the previous PR, I missed a comma in the unit test file.

I have verified that all tests now pass locally:
```
[09:07:52] ~/dev/CGI--Simple
 {0} $ prove -I lib t/
t/000.load.t ......... 1/1 # Testing CGI::Simple 1.280
t/000.load.t ......... ok   
t/020.cookie.t ....... ok       
t/030.function.t ..... ok     
t/040.request.t ...... ok     
t/041.multipart.t .... ok   
t/050.simple.t ....... ok       
t/060.slow_post.t .... ok   
t/070.standard.t ..... ok       
t/080.util.t ......... ok     
t/090.14838.t ........ ok   
t/100.set-cookie.t ... ok   
t/110.bad-upload.t ... ok   
t/120.header-crlf.t .. ok   
t/headers.t .......... ok   
t/upload_info.t ...... ok   
t/version.t .......... ok   
All tests successful.
Files=16, Tests=890, 11 wallclock secs ( 0.08 usr  0.04 sys +  1.03 cusr  0.21 csys =  1.36 CPU)
Result: PASS
```
